### PR TITLE
Remove Permissive Cross Domain Policy for Flash

### DIFF
--- a/src/sentry/templates/sentry/crossdomain.xml
+++ b/src/sentry/templates/sentry/crossdomain.xml
@@ -2,8 +2,4 @@
 <!DOCTYPE cross-domain-policy SYSTEM
     "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    {% for origin in origin_list %}
-        <allow-access-from domain="{{ origin }}" secure="false" />
-    {% endfor %}
-    <allow-http-request-headers-from domain="*" headers="*" secure="false" />
 </cross-domain-policy>

--- a/src/sentry/templates/sentry/crossdomain_index.xml
+++ b/src/sentry/templates/sentry/crossdomain_index.xml
@@ -2,6 +2,4 @@
 <!DOCTYPE cross-domain-policy SYSTEM
     "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <site-control permitted-cross-domain-policies="all" />
-    <allow-http-request-headers-from domain="*" headers="*" secure="false" />
 </cross-domain-policy>


### PR DESCRIPTION
Remove permissive cross-domain policy for Flash. This will remove support for submitting events to Sentry from Flash (ActionScript) for this fork of Sentry.